### PR TITLE
Add bigint support from ts to coretypes

### DIFF
--- a/lib/ts-to-core-types.test.ts
+++ b/lib/ts-to-core-types.test.ts
@@ -64,6 +64,21 @@ it( "negative numeric literal type", ( ) =>
 	] );
 } );
 
+it( "BigInt Support", ( ) =>
+{
+	const coreTypes = convertTypeScriptToCoreTypes( `
+	export type Foo = bigint;
+	` ).data.types;
+
+	equal( coreTypes, [
+		{
+			name: 'Foo',
+			title: 'Foo',
+			type: 'integer',
+		}
+	] );
+} );
+
 it( "basic interface with additional properties", ( ) =>
 {
 	const coreTypes = convertTypeScriptToCoreTypes( `

--- a/lib/ts-to-core-types.ts
+++ b/lib/ts-to-core-types.ts
@@ -528,6 +528,9 @@ function fromTsTypeNode(
 	else if ( node.kind === ts.SyntaxKind.NumberKeyword )
 		return { type: 'number', ...decorateNode( node ) };
 
+	else if ( node.kind === ts.SyntaxKind.BigIntKeyword )
+		return { type: 'integer', ...decorateNode( node ) };
+
 	else if ( node.kind === ts.SyntaxKind.BooleanKeyword )
 		return { type: 'boolean', ...decorateNode( node ) };
 


### PR DESCRIPTION
BigInt has been added for a while now in JS and TS has added support for it since TS 3.2. I have a usecase that uses BigInts and this adds support for it. (From TS to coretypes). I can also add support from coreTypes to TS, if wanted should I add a option to enable bigInts? 