### PR TITLE
Support generic types

### DIFF
--- a/lib/ts-to-core-types.test.ts
+++ b/lib/ts-to-core-types.test.ts
@@ -48,6 +48,101 @@ it( "object literal type", ( ) =>
 	] );
 } );
 
+it( "object generic", ( ) =>
+{
+	const coreTypes = convertTypeScriptToCoreTypes( `
+	export interface Generic<R> {
+		foo: string;
+		bar: R;
+	}
+	
+	export interface UseGenericWithString{
+		gen: Generic<string>
+	}
+	
+	export interface UseGenericWithNumber{
+		gen: Generic<number>
+	}
+	` ).data.types;
+
+	equal( coreTypes, [
+		{
+			"additionalProperties": false,
+			"name": "UseGenericWithString",
+			"properties": {
+				"gen": {
+					"node": {
+						"ref": "Generic_string",
+						"title": "UseGenericWithString.gen",
+						"type": "ref"
+					},
+					"required": true
+				}
+			},
+			"title": "UseGenericWithString",
+			"type": "object"
+		},
+		{
+			"additionalProperties": false,
+			"name": "UseGenericWithNumber",
+			"properties": {
+				"gen": {
+					"node": {
+						"ref": "Generic_number",
+						"title": "UseGenericWithNumber.gen",
+						"type": "ref"
+					},
+					"required": true
+				}
+			},
+			"title": "UseGenericWithNumber",
+			"type": "object"
+		},
+		{
+			"additionalProperties": false,
+			"name": "Generic_string",
+			"properties": {
+				"bar": {
+					"node": {
+						"title": "Generic.bar",
+						"type": "string"
+					},
+					"required": true
+				},
+				"foo": {
+					"node": {
+						"title": "Generic.foo",
+						"type": "string"
+					},
+					"required": true
+				}
+			},
+			"type": "object"
+		},
+		{
+			"additionalProperties": false,
+			"name": "Generic_number",
+			"properties": {
+				"bar": {
+					"node": {
+						"title": "Generic.bar",
+						"type": "number"
+					},
+					"required": true
+				},
+				"foo": {
+					"node": {
+						"title": "Generic.foo",
+						"type": "string"
+					},
+					"required": true
+				}
+			},
+			"type": "object"
+		}
+	] );
+} );
+
 it( "negative numeric literal type", ( ) =>
 {
 	const coreTypes = convertTypeScriptToCoreTypes( `


### PR DESCRIPTION
This is a very early draft to present an idea on how to handle generic types in TypeScript ([typeconv#36](https://github.com/grantila/typeconv/issues/36)). Basically, the idea is that for every constellation of type arguments used, generate a new ref for that constellation.

I have not cared about styling and/or conventions in this draft. I will clean it up, handle more cases, add more tests if you think that my approach is acceptable. So, @grantila do you think this approach is acceptable?